### PR TITLE
Looser peerDependencies for CDK modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ for more details on what's available.
 Additionally, a CDK `Construct` is exposed, should you want to add additional
 customizations vs. using the out-of-the-box `Stack`.
 
+## CDK Version Compatibility
+
+This package is expected to work with all recent versions of CDK
+v1. It has been tested with 1.55.0 so almost certainly works will all
+newer versions, and probably works with some older versions too, but
+is untested.
+
 ## How it Works
 
 This module uses the

--- a/package.json
+++ b/package.json
@@ -47,10 +47,10 @@
   "dependencies": {},
   "peerDependencies": {
     "constructs": "^3.0.4",
-    "@aws-cdk/core": "^1.64.1",
-    "@aws-cdk/aws-secretsmanager": "^1.64.1",
-    "@aws-cdk/aws-cloudformation": "^1.64.1",
-    "@aws-cdk/aws-s3": "^1.64.1"
+    "@aws-cdk/core": "^1.0.0",
+    "@aws-cdk/aws-secretsmanager": "^1.0.0",
+    "@aws-cdk/aws-cloudformation": "^1.0.0",
+    "@aws-cdk/aws-s3": "^1.0.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
While I don't believe this is totally accurate, as such, I suspect that there are CDK versions below 1.64 where this module will work fine, but it looks like npm is now stricter when peer dependencies are not satisfied.

Attempting to install this module where I'm using an older version of CDK, I get an error like:
```
$ npm i --save cdk-datadog-integration
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: myproject@1.0.0
npm ERR! Found: @aws-cdk/aws-cloudwatch@1.102.0
npm ERR! node_modules/@aws-cdk/aws-cloudwatch
npm ERR!   peer @aws-cdk/aws-cloudwatch@"1.102.0" from @aws-cdk/aws-lambda@1.102.0
npm ERR!   node_modules/@aws-cdk/aws-lambda
npm ERR!     peer @aws-cdk/aws-lambda@"1.102.0" from @aws-cdk/aws-cloudformation@1.102.0
npm ERR!     node_modules/@aws-cdk/aws-cloudformation
npm ERR!       peer @aws-cdk/aws-cloudformation@"^1.64.1" from cdk-datadog-integration@1.1.1
npm ERR!       node_modules/cdk-datadog-integration
npm ERR!         cdk-datadog-integration@"*" from the root project
npm ERR!   peer @aws-cdk/aws-cloudwatch@"1.102.0" from @aws-cdk/aws-applicationautoscaling@1.102.0
npm ERR!   node_modules/@aws-cdk/aws-applicationautoscaling
npm ERR!     peer @aws-cdk/aws-applicationautoscaling@"1.102.0" from @aws-cdk/aws-lambda@1.102.0
npm ERR!     node_modules/@aws-cdk/aws-lambda
npm ERR!       peer @aws-cdk/aws-lambda@"1.102.0" from @aws-cdk/aws-cloudformation@1.102.0
npm ERR!       node_modules/@aws-cdk/aws-cloudformation
npm ERR!         peer @aws-cdk/aws-cloudformation@"^1.64.1" from cdk-datadog-integration@1.1.1
npm ERR!         node_modules/cdk-datadog-integration
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer @aws-cdk/aws-cloudwatch@"1.55.0" from @aws-cdk/aws-ec2@1.55.0
npm ERR! node_modules/@aws-cdk/aws-ec2
npm ERR!   @aws-cdk/aws-ec2@"1.55.0" from the root project
```

That is, npm is - not unreasonably - complaining because my `package.json` has `"@aws-cdk/aws-ec2": "1.55.0"` but this module has `"@aws-cdk/aws-cloudformation": "^1.64.1"`, and each of those wants a compatible `@aws-cdk/aws-cloudwatch`, which are incompatible. It looks like this is different behaviour between npm 6 and 7, where 6 was more lenient, but 7 errors.

One option would be for me to upgrade CDK. In my case that is not possible.
Another would be to update this modules `package.json` to have the loosest functioning peer dependencies, but alas, I'm just not that diligent.
Thus, I have arrived at the changes that I have here.