### PR TITLE
fix: correct datadog_integration_role.yml parameter to match new value

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -150,7 +150,7 @@ export class DatadogIntegration extends cdk.Construct {
         parameters: Object.assign(
           {
             ExternalId: props.externalId,
-            Permissions: props.permissions.toString(),
+            BasePermissions: props.permissions.toString(),
             IAMRoleName: props.iamRoleName,
             LogArchives: bucketsToString(props.logArchives),
             CloudTrails: bucketsToString(props.cloudTrails),

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -48,7 +48,7 @@ describe("DatadogIntegrationStack", () => {
             "https://datadog-cloudformation-template.s3.amazonaws.com/aws/datadog_integration_role.yaml",
           Parameters: {
             ExternalId: "not-a-real-id",
-            Permissions: "Full",
+            BasePermissions: "Full",
             IAMRoleName: "DatadogIntegrationRole",
             LogArchives: "",
             CloudTrails: "",
@@ -105,7 +105,7 @@ describe("DatadogIntegrationStack", () => {
             "https://datadog-cloudformation-template.s3.amazonaws.com/aws/datadog_integration_role.yaml",
           Parameters: {
             ExternalId: "not-a-real-id",
-            Permissions: "Full",
+            BasePermissions: "Full",
             IAMRoleName: "MyRoleName", // the sub-assert
             LogArchives: "",
             CloudTrails: "",
@@ -128,7 +128,7 @@ describe("DatadogIntegrationStack", () => {
             "https://datadog-cloudformation-template.s3.amazonaws.com/aws/datadog_integration_role.yaml",
           Parameters: {
             ExternalId: "not-a-real-id",
-            Permissions: "Core",
+            BasePermissions: "Core",
             IAMRoleName: "DatadogIntegrationRole",
             LogArchives: "",
             CloudTrails: "",
@@ -152,7 +152,7 @@ describe("DatadogIntegrationStack", () => {
             "https://datadog-cloudformation-template.s3.amazonaws.com/aws/datadog_integration_role.yaml",
           Parameters: {
             ExternalId: "not-a-real-id",
-            Permissions: "Full",
+            BasePermissions: "Full",
             IAMRoleName: "DatadogIntegrationRole",
             LogArchives: {
               "Fn::ImportValue": "Stack:ExportsOutputRefBucket83908E7781C90AC0", // the sub-assert
@@ -179,7 +179,7 @@ describe("DatadogIntegrationStack", () => {
             "https://datadog-cloudformation-template.s3.amazonaws.com/aws/datadog_integration_role.yaml",
           Parameters: {
             ExternalId: "not-a-real-id",
-            Permissions: "Full",
+            BasePermissions: "Full",
             IAMRoleName: "DatadogIntegrationRole",
             LogArchives: {
               // the sub-assert
@@ -219,7 +219,7 @@ describe("DatadogIntegrationStack", () => {
             "https://datadog-cloudformation-template.s3.amazonaws.com/aws/datadog_integration_role.yaml",
           Parameters: {
             ExternalId: "not-a-real-id",
-            Permissions: "Full",
+            BasePermissions: "Full",
             IAMRoleName: "DatadogIntegrationRole",
             LogArchives: "",
             CloudTrails: {
@@ -246,7 +246,7 @@ describe("DatadogIntegrationStack", () => {
             "https://datadog-cloudformation-template.s3.amazonaws.com/aws/datadog_integration_role.yaml",
           Parameters: {
             ExternalId: "not-a-real-id",
-            Permissions: "Full",
+            BasePermissions: "Full",
             IAMRoleName: "DatadogIntegrationRole",
             LogArchives: "",
             CloudTrails: {
@@ -287,7 +287,7 @@ describe("DatadogIntegrationStack", () => {
             "https://datadog-cloudformation-template.s3.amazonaws.com/aws/datadog_integration_role.yaml",
           Parameters: {
             ExternalId: "not-a-real-id",
-            Permissions: "Full",
+            BasePermissions: "Full",
             IAMRoleName: "DatadogIntegrationRole",
             LogArchives: "",
             CloudTrails: "",
@@ -303,7 +303,7 @@ describe("DatadogIntegrationStack", () => {
         apiKey: secret,
         externalId: "not-a-real-id",
         additionalIntegrationRoleParams: {
-          Permissions: "SomeNewThing",
+          BasePermissions: "SomeNewThing",
         },
       });
 
@@ -313,7 +313,7 @@ describe("DatadogIntegrationStack", () => {
             "https://datadog-cloudformation-template.s3.amazonaws.com/aws/datadog_integration_role.yaml",
           Parameters: {
             ExternalId: "not-a-real-id",
-            Permissions: "SomeNewThing",
+            BasePermissions: "SomeNewThing",
             IAMRoleName: "DatadogIntegrationRole",
             LogArchives: "",
             CloudTrails: "",


### PR DESCRIPTION
The `datadog_integration_role.yml` template changed the name of the `Permissions` parameter to `BasePermissions`, which caused errors like this when upgrading the stack:

```
 2/5 | 11:31:31 PM | UPDATE_FAILED        | AWS::CloudFormation::Stack | Datadog/AwsIntegration/IntegrationRoleStack (IntegrationRoleStack) Parameters: [Permissions] do not exist in the template
 2/5 | 11:31:31 PM | UPDATE_FAILED        | AWS::CloudFormation::Stack | Datadog/AwsIntegration/ForwarderStack (ForwarderStack) Resource update cancelled
```