### PR TITLE
fix: restore python by removing source-map-support/register

### DIFF
--- a/.jsii
+++ b/.jsii
@@ -688,7 +688,7 @@
       "initializer": {
         "locationInModule": {
           "filename": "lib/index.ts",
-          "line": 116
+          "line": 115
         },
         "parameters": [
           {
@@ -714,7 +714,7 @@
       "kind": "class",
       "locationInModule": {
         "filename": "lib/index.ts",
-        "line": 113
+        "line": 112
       },
       "name": "DatadogIntegration"
     },
@@ -725,7 +725,7 @@
       "kind": "interface",
       "locationInModule": {
         "filename": "lib/index.ts",
-        "line": 13
+        "line": 12
       },
       "name": "DatadogIntegrationConfig",
       "properties": [
@@ -737,7 +737,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "lib/index.ts",
-            "line": 17
+            "line": 16
           },
           "name": "apiKey",
           "type": {
@@ -752,7 +752,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "lib/index.ts",
-            "line": 23
+            "line": 22
           },
           "name": "externalId",
           "type": {
@@ -768,7 +768,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "lib/index.ts",
-            "line": 96
+            "line": 95
           },
           "name": "additionalForwarderParams",
           "optional": true,
@@ -790,7 +790,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "lib/index.ts",
-            "line": 108
+            "line": 107
           },
           "name": "additionalIntegrationRoleParams",
           "optional": true,
@@ -812,7 +812,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "lib/index.ts",
-            "line": 86
+            "line": 85
           },
           "name": "cloudTrails",
           "optional": true,
@@ -835,7 +835,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "lib/index.ts",
-            "line": 55
+            "line": 54
           },
           "name": "forwarderName",
           "optional": true,
@@ -853,7 +853,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "lib/index.ts",
-            "line": 64
+            "line": 63
           },
           "name": "forwarderVersion",
           "optional": true,
@@ -870,7 +870,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "lib/index.ts",
-            "line": 38
+            "line": 37
           },
           "name": "iamRoleName",
           "optional": true,
@@ -887,7 +887,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "lib/index.ts",
-            "line": 72
+            "line": 71
           },
           "name": "installDatadogPolicyMacro",
           "optional": true,
@@ -904,7 +904,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "lib/index.ts",
-            "line": 79
+            "line": 78
           },
           "name": "logArchives",
           "optional": true,
@@ -927,7 +927,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "lib/index.ts",
-            "line": 46
+            "line": 45
           },
           "name": "permissions",
           "optional": true,
@@ -945,7 +945,7 @@
           "immutable": true,
           "locationInModule": {
             "filename": "lib/index.ts",
-            "line": 31
+            "line": 30
           },
           "name": "site",
           "optional": true,
@@ -962,7 +962,7 @@
       "initializer": {
         "locationInModule": {
           "filename": "lib/index.ts",
-          "line": 194
+          "line": 193
         },
         "parameters": [
           {
@@ -988,7 +988,7 @@
       "kind": "class",
       "locationInModule": {
         "filename": "lib/index.ts",
-        "line": 193
+        "line": 192
       },
       "name": "DatadogIntegrationStack"
     },
@@ -1003,11 +1003,11 @@
       "kind": "interface",
       "locationInModule": {
         "filename": "lib/index.ts",
-        "line": 189
+        "line": 188
       },
       "name": "DatadogIntegrationStackConfig"
     }
   },
   "version": "1.2.2",
-  "fingerprint": "SgpzGUKtiuGGPXLeH/01OBT2Z1oD+WxvGAIyQDh24YE="
+  "fingerprint": "9LAXwA6IYyXC56oVIHQsdAk1RyBN6MfpA8E+Z2/afrA="
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,3 @@
-import "source-map-support/register";
 import * as cdk from "@aws-cdk/core";
 import * as cfn from "@aws-cdk/aws-cloudformation";
 import * as secrets from "@aws-cdk/aws-secretsmanager";

--- a/tsconfig.tsbuildinfo
+++ b/tsconfig.tsbuildinfo
@@ -1126,7 +1126,7 @@
         "affectsGlobalScope": false
       },
       "./lib/index.ts": {
-        "version": "183a8dbac642f406b3781c121b9794033d86ccedc3cd81a5130b1cf83c71a420",
+        "version": "bd3fe6e276b29c46347717a2d46cde51f08f4964813726258a18f51f1687b6fa",
         "affectsGlobalScope": false
       },
       "./lib/config.ts": {
@@ -1425,7 +1425,7 @@
         "version": "f5638f7c2f12a9a1a57b5c41b3c1ea7db3876c003bab68e6a57afd6bcc169af0",
         "affectsGlobalScope": false
       },
-      "./node_modules/jest-diff/build/cleanupSemantic.d.ts": {
+      "./node_modules/jest-diff/build/cleanupsemantic.d.ts": {
         "version": "d8aab31ba8e618cc3eea10b0945de81cb93b7e8150a013a482332263b9305322",
         "affectsGlobalScope": false
       },
@@ -1433,11 +1433,11 @@
         "version": "69da61a7b5093dac77fa3bec8be95dcf9a74c95a0e9161edb98bb24e30e439d2",
         "affectsGlobalScope": false
       },
-      "./node_modules/jest-diff/build/diffLines.d.ts": {
+      "./node_modules/jest-diff/build/difflines.d.ts": {
         "version": "561eca7a381b96d6ccac6e4061e6d2ae53f5bc44203f3fd9f5b26864c32ae6e9",
         "affectsGlobalScope": false
       },
-      "./node_modules/jest-diff/build/printDiffs.d.ts": {
+      "./node_modules/jest-diff/build/printdiffs.d.ts": {
         "version": "62ea38627e3ebab429f7616812a9394d327c2bc271003dfba985de9b4137369f",
         "affectsGlobalScope": false
       },
@@ -2980,18 +2980,18 @@
         "./node_modules/constructs/lib/construct.d.ts",
         "./node_modules/constructs/lib/metadata.d.ts"
       ],
-      "./node_modules/jest-diff/build/diffLines.d.ts": [
-        "./node_modules/jest-diff/build/cleanupSemantic.d.ts",
+      "./node_modules/jest-diff/build/difflines.d.ts": [
+        "./node_modules/jest-diff/build/cleanupsemantic.d.ts",
         "./node_modules/jest-diff/build/types.d.ts"
       ],
       "./node_modules/jest-diff/build/index.d.ts": [
-        "./node_modules/jest-diff/build/cleanupSemantic.d.ts",
-        "./node_modules/jest-diff/build/diffLines.d.ts",
-        "./node_modules/jest-diff/build/printDiffs.d.ts",
+        "./node_modules/jest-diff/build/cleanupsemantic.d.ts",
+        "./node_modules/jest-diff/build/difflines.d.ts",
+        "./node_modules/jest-diff/build/printdiffs.d.ts",
         "./node_modules/jest-diff/build/types.d.ts"
       ],
-      "./node_modules/jest-diff/build/printDiffs.d.ts": [
-        "./node_modules/jest-diff/build/cleanupSemantic.d.ts",
+      "./node_modules/jest-diff/build/printdiffs.d.ts": [
+        "./node_modules/jest-diff/build/cleanupsemantic.d.ts",
         "./node_modules/jest-diff/build/types.d.ts"
       ],
       "./node_modules/pretty-format/build/index.d.ts": [


### PR DESCRIPTION
Fixes #15

I tested this out in a sample CDK application and everything's working now.