### PR TITLE
POC: Extracts forwarder stack

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,7 @@ const CONFIG_DEFAULTS: DatadogIntegrationDefaults = Object.freeze({
   forwarderName: 'DatadogForwarder',
   forwarderVersion: 'latest',
   installDatadogPolicyMacro: true,
+  installDatadogForwarder: true,
 });
 
 export type DatadogIntegrationConfigWithDefaults = DatadogIntegrationConfig &

--- a/src/forwarder.ts
+++ b/src/forwarder.ts
@@ -1,0 +1,53 @@
+import * as cfn from 'aws-cdk-lib/aws-cloudformation';
+import { Construct } from 'constructs';
+
+export interface ForwarderStackProps extends Omit<cfn.CfnStackProps, 'templateUrl'>{
+  forwarderVersion: string;
+  templateParameters: ForwarderTemplateParameters;
+}
+
+export interface ForwarderTemplateParameters{
+  /**
+     * The Datadog API key, which can be found from the APIs page (/account/settings#api). It will be stored in AWS Secrets Manager securely. If DdApiKeySecretArn is also set, this value will not be used. This value must still be set, however.
+     * @default 'USE_ARN'
+     */
+  DdApiKey?: string;
+
+  /**
+     * The ARN of the secret storing the Datadog API key, if you already have it stored in Secrets Manager. You still need to set a dummy value for "DdApiKey" to satisfy the requirement, though that value won't be used.
+     */
+  DdApiKeySecretArn?: string;
+
+  /**
+     *  The Datadog Forwarder Lambda function name. DO NOT change when updating an existing CloudFormation stack, otherwise the current forwarder function will be replaced and all the triggers will be lost.
+     * @default DatadogForwarder
+     */
+  FunctionName?: string;
+
+  /**
+     * Define your Datadog Site to send data to. For the Datadog EU site, set to datadoghq.eu
+     * @default datadoghq.com
+     */
+  DdSite?: string;
+}
+export class ForwarderStack extends cfn.CfnStack {
+
+  constructor(scope: Construct, id: string, props: ForwarderStackProps) {
+
+    const templateParams: ForwarderTemplateParameters = {
+      DdApiKey: 'USE_ARN',
+      DdApiKeySecretArn: props.templateParameters.DdApiKeySecretArn,
+      DdSite: props.templateParameters.DdSite,
+      FunctionName: props.templateParameters.DdSite,
+      ...props.templateParameters,
+    };
+
+    const templateParamsAsDict: { [key: string]: (string) } = Object.entries(templateParams)
+      .reduce((all, [key, value]) => ({ ...all, [key]: value.toString() }), {});
+
+    super(scope, id, {
+      templateUrl: `https://datadog-cloudformation-template.s3.amazonaws.com/aws/forwarder/${props.forwarderVersion}.yaml`,
+      parameters: templateParamsAsDict,
+    });
+  }
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -407,7 +407,7 @@ describe('DatadogIntegrationStack', () => {
         apiKey: secret,
         externalId: 'not-a-real-id',
         additionalForwarderParams: {
-          Foo: 'bar',
+          FunctionName: 'bar',
         },
       });
 
@@ -421,8 +421,7 @@ describe('DatadogIntegrationStack', () => {
             'Fn::ImportValue': 'Stack:ExportsOutputRefSecretA720EF052D953DED',
           },
           DdSite: 'datadoghq.com',
-          FunctionName: 'DatadogForwarder',
-          Foo: 'bar', // the sub-assert
+          FunctionName: 'bar',
         },
       });
     });


### PR DESCRIPTION
In order to configure multiple regions, one has to configure the Forwarder stack in each region. This is currently not supported as:
* You can't opt out of installing the Forwarder stack
* You can't separately use the stack in order to deploy it in additional regions.

This PR is a POC of separating concerns and adding an opt-out option for the forwarder.

If this approach is acceptable, I'm happy to add the rest of the stack parameters, test cases, and documentation.

wdyt?