### PR TITLE
fix: Change addDependsOn to addDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@types/node": "^14",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
-    "aws-cdk-lib": "2.1.0",
+    "aws-cdk-lib": "2.56.0",
     "constructs": "10.0.5",
     "eslint": "^8",
     "eslint-import-resolver-node": "^0.3.6",

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,7 +162,7 @@ export class DatadogIntegration extends Construct {
     );
 
     if (policyMacroStack) {
-      integrationRoleStack.addDependsOn(policyMacroStack);
+      integrationRoleStack.addDependency(policyMacroStack);
     }
 
     return integrationRoleStack;


### PR DESCRIPTION
addDependsOn is deprecated:

```
❯ yarn cdk synth
info: Preparing App...
[WARNING] aws-cdk-lib.CfnResource#addDependsOn is deprecated.
  use addDependency
  This API will be removed in the next major release.
[WARNING] aws-cdk-lib.CfnResource#addDependsOn is deprecated.
  use addDependency
  This API will be removed in the next major release.
```
